### PR TITLE
Add GitHub testing workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test job
+    strategy:
+      matrix:
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        platform: ["ubuntu-18.04", "ubuntu-20.04", "ubuntu-22.04"]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Python ${{ matrix.python }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install tox
+        run: python -m pip install -U tox
+      - name: Lint
+        run: python -m tox -e lint
+      - name: Run unit tests
+        run: python -m tox -e unit
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Run integration tests
+        run: python -m tox -e integration


### PR DESCRIPTION
Adds a testing workflow to GitHub actions to evaluate tox tests for all pushes and pull requests. This gives repository contributors the ability to evaluate the health of submitted code quickly.

The action runs across common Ubuntu platforms in use on several clouds. It also iterates through several Python versions to ensure maximum compatibility.

The following is an example of a workflow run:
https://github.com/johnlettman/charm-local-juju-users/actions/runs/5813904296
<sup><sub>(unfortunately, the present `main` branch has a function with too much complexity, triggering a failure)</sub></sup>

The action uses [Codecov](https://codecov.io/), [common in existing Canonical repositories](https://app.codecov.io/gh/canonical).
This requires a repository secret called `CODECOV_TOKEN`. **Please establish the token before merging.**

Note: admin permissions are required to access repo settings > secrets and variable > actions.