### PR TITLE
Add GitHub Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    assignees: ["przemeklal"]
+    reviewers: ["przemeklal"]
+    open-pull-requests-limit: 6
+    schedule:
+      day: "monday"
+      timezone: "10:00 CEST"
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,19 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    assignees: ["przemeklal"]
+    reviewers: ["przemeklal"]
+    open-pull-requests-limit: 2
+    commit-message:
+      # Skip CI when updating, well, CI.
+      # See: https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
+      prefix: '[skip ci] '
+    schedule:
+      day: "monday"
+      timezone: "10:00 CEST"
+      interval: "weekly"
+
   - package-ecosystem: "pip"
     directory: "/"
     assignees: ["przemeklal"]


### PR DESCRIPTION
Adds configuration for GitHub's integrated automated dependency tracker, Dependabot. This is a handy tool for keeping dependencies up to date, particularly when those dependencies require security patches.

When configured, the tool will populate the "Security" tab with advisories about the project dependencies. In addition, it will open PRs to resolve advisories and out-of-date dependencies.

![Screenshot of the Dependabot security tab](https://github.com/canonical/charm-local-juju-users/assets/20583294/e9415893-3baf-4c73-80e2-c759b4e0cfac)


This configuration assigns the version update pull requests to the current repository owner, @przemeklal. It will open PRs on Monday at 10:00 AM CEST weekly, ensuring a comfortable schedule, without noise, within the TZ of the current repository owner.