### PR TITLE
Implement SSH key type selection

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -43,3 +43,10 @@ options:
       - /home/ubuntu/.kube/:/home/$USER/.kube
     default: ""
     type: string
+  ssh-key-type:
+    description: |
+      The SSH type format that will be used for user personal keys.
+      Values: rsa, dsa, ecdsa, or ed25519
+      Usage of dsa is not recommended unless there exist a practical compatibility rationale.
+    default: "ed25519"
+    type: string

--- a/lib/local_juju_users.py
+++ b/lib/local_juju_users.py
@@ -29,7 +29,7 @@ import subprocess
 import yaml
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa, dsa, ec, ed25519
+from cryptography.hazmat.primitives.asymmetric import dsa, ec, ed25519, rsa
 from jinja2 import Environment, FileSystemLoader
 from pkg_resources import packaging
 
@@ -164,8 +164,7 @@ def get_ssh_key(user, key_type="ed25519"):
     """Return the SSH key for a user."""
     # TOFIX: home dir location?
     # TOFIX: make sure the key exists
-    public_key_path = ("/home/{}/.ssh/personal_juju_id_{}.pub"
-                       .format(user, key_type))
+    public_key_path = "/home/{}/.ssh/personal_juju_id_{}.pub".format(user, key_type)
     with open(public_key_path, "r") as f:
         public_key = f.read()
     return public_key
@@ -234,43 +233,39 @@ def save_credentials_file(user, credentials):
 
 
 def generate_rsa_key_pair():
+    """Generate a RSA key pair."""
     private_key = rsa.generate_private_key(
-        public_exponent=65537,
-        key_size=2048,
-        backend=default_backend()
+        public_exponent=65537, key_size=2048, backend=default_backend()
     )
     return private_key
 
 
 def generate_dsa_key_pair():
-    private_key = dsa.generate_private_key(
-        key_size=2048,
-        backend=default_backend()
-    )
+    """Generate a DSA key pair."""
+    private_key = dsa.generate_private_key(key_size=2048, backend=default_backend())
     return private_key
 
 
 def generate_ecdsa_key_pair():
-    private_key = ec.generate_private_key(
-        ec.SECP256R1(),
-        default_backend()
-    )
+    """Generate an ECDSA key pair."""
+    private_key = ec.generate_private_key(ec.SECP256R1(), default_backend())
     return private_key
 
 
 def generate_ed25519_key_pair():
+    """Generate an Ed25519 key pair."""
     private_key = ed25519.Ed25519PrivateKey.generate()
     return private_key
 
 
 def generate_ssh_key_pair(user, key_type="ed25519"):
     """Generate an SSH key pair based on key_type."""
-
     # Validate key_type
     valid_key_types = ["rsa", "dsa", "ecdsa", "ed25519"]
     if key_type not in valid_key_types:
-        raise ValueError("Invalid key_type. Valid choices are: {}"
-                         .format(", ".join(valid_key_types)))
+        raise ValueError(
+            "Invalid key_type. Valid choices are: {}".format(", ".join(valid_key_types))
+        )
 
     # Key generation based on key_type
     if key_type == "rsa":

--- a/src/charm.py
+++ b/src/charm.py
@@ -404,7 +404,7 @@ class LocalJujuUsersCharm(ops.charm.CharmBase):
                     return
 
             # ensure that ssh key and config exists, create if needed
-            setup_ssh_key(user)
+            setup_ssh_key(user, key_type=self.model.config["ssh-key-type"])
             setup_ssh_config(user)
 
             # only the leader is responsible for setting up access to juju


### PR DESCRIPTION
Per #22, this branch implements an end-user choice for SSH key types, supporting a range of common ones:
- `rsa`
- `dsa` (not recommended, but available)
- `ecdsa` (current default)
- `ed25519` (new default in branch)

There is additional discussion in #22 regarding this change's rationale.

The key generation is generalized into 4 compatible functions sporting a similar signature for use elsewhere in the library:
https://github.com/canonical/charm-local-juju-users/blob/a5e85e39022fbb6856dc722af2461498fad25269/lib/local_juju_users.py#L236-L263

As a result, the modifications to `generate_ssh_key_pair` make use of those generalizations to populate `private_key` with any of the supported types per user selection:
https://github.com/canonical/charm-local-juju-users/blob/a5e85e39022fbb6856dc722af2461498fad25269/lib/local_juju_users.py#L266-L283

The configuration item is configured here:
https://github.com/johnlettman/charm-local-juju-users/blob/ba1f7bd6607970afb2d38ec63a5a09f2361f23fc/config.yaml#L46-L52

The selection populates through the library functions from here:
https://github.com/johnlettman/charm-local-juju-users/blob/ba1f7bd6607970afb2d38ec63a5a09f2361f23fc/src/charm.py#L407