### PR TITLE
fixed fix ignored-controllers option

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -289,12 +289,12 @@ class LocalJujuUsersCharm(ops.charm.CharmBase):
     def _get_ignored_controllers(self):
         """Return the user-specified ignored controllers list."""
         if (
-            self.model.config["ignored_controllers"]
-            and len(self.model.config["ignored_controllers"].strip()) > 0
+            self.model.config["ignored-controllers"]
+            and len(self.model.config["ignored-controllers"].strip()) > 0
         ):
             return [
                 controller.strip()
-                for controller in self.model.config["ignored.controllers"].split(",")
+                for controller in self.model.config["ignored-controllers"].split(",")
             ]
 
         return []


### PR DESCRIPTION
When running the `synchronize-accounts` action, I got the following errors:
```
unit-local-juju-users-0: 07:43:35 ERROR unit.local-juju-users/0.juju-log Uncaught exception while in charm code:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-local-juju-users-0/charm/./src/charm.py", line 508, in <module>
    main(LocalJujuUsersCharm)
  File "/var/lib/juju/agents/unit-local-juju-users-0/charm/venv/ops/main.py", line 438, in main
    _emit_charm_event(charm, dispatcher.event_name)
  File "/var/lib/juju/agents/unit-local-juju-users-0/charm/venv/ops/main.py", line 150, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-local-juju-users-0/charm/venv/ops/framework.py", line 355, in emit
    framework._emit(event)  # noqa
  File "/var/lib/juju/agents/unit-local-juju-users-0/charm/venv/ops/framework.py", line 856, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-local-juju-users-0/charm/venv/ops/framework.py", line 931, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-local-juju-users-0/charm/./src/charm.py", line 379, in _synchronize_accounts
    ignored_controllers = self._get_ignored_controllers()
  File "/var/lib/juju/agents/unit-local-juju-users-0/charm/./src/charm.py", line 292, in _get_ignored_controllers
    self.model.config["ignored_controllers"]
  File "/var/lib/juju/agents/unit-local-juju-users-0/charm/venv/ops/model.py", line 547, in __getitem__
    return self._data[key]
KeyError: 'ignored_controllers'
```
This PR fixes the error.